### PR TITLE
labAdmin: show devices available on the network

### DIFF
--- a/labAdmin/admin.py
+++ b/labAdmin/admin.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
 from labAdmin.models import *
 
+from .arp import get_neighbours
+
 
 class CardAdmin(admin.ModelAdmin):
     list_display = ('nfc_id', 'credits')
@@ -45,6 +47,22 @@ admin.site.register(Category, CategoryAdmin)
 class DeviceAdmin(admin.ModelAdmin):
     list_display = ('name', 'hourlyCost', 'category', 'mac',)
     ordering = ('name',)
+    change_form_template = 'labadmin/admin/device_change_form.html'
+    add_form_template = 'labadmin/admin/device_change_form.html'
+
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        extra_context = extra_context or {}
+        extra_context['labadmin_available_devices'] = get_neighbours()
+        return super(DeviceAdmin, self).change_view(
+            request, object_id, form_url, extra_context=extra_context
+        )
+
+    def add_view(self, request, form_url='', extra_context=None):
+        extra_context = extra_context or {}
+        extra_context['labadmin_available_devices'] = get_neighbours()
+        return super(DeviceAdmin, self).add_view(
+            request, form_url, extra_context=extra_context
+        )
 
 admin.site.register(Device, DeviceAdmin)
 

--- a/labAdmin/arp.py
+++ b/labAdmin/arp.py
@@ -1,0 +1,20 @@
+IP_INDEX = 0
+MAC_INDEX = 3
+NUM_FIELDS = 6
+
+
+def get_neighbours():
+    """
+    Returns a generator of ip address, mac address tuples.
+    Empty mac addresses are filtered out.
+    """
+    with open('/proc/net/arp', 'r') as f:
+        # skip header
+        next(f)
+        for row in f:
+            fields = row.split()
+            if len(fields) < NUM_FIELDS:
+                continue
+            if fields[MAC_INDEX] == '00:00:00:00:00:00':
+                continue
+            yield fields[IP_INDEX], fields[MAC_INDEX]

--- a/labAdmin/templates/labadmin/admin/device_change_form.html
+++ b/labAdmin/templates/labadmin/admin/device_change_form.html
@@ -1,0 +1,43 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls %}
+
+{% block object-tools %}
+{% if not is_popup %}
+  <ul class="object-tools">
+    {% block object-tools-items %}
+    {% if change %}
+    <li>
+        {% url opts|admin_urlname:'history' original.pk|admin_urlquote as history_url %}
+        <a href="{% add_preserved_filters history_url %}" class="historylink">{% trans "History" %}</a>
+    </li>
+    {% if has_absolute_url %}<li><a href="{{ absolute_url }}" class="viewsitelink">{% trans "View on site" %}</a></li>{% endif %}
+    {% endif %}
+	{% if labadmin_available_devices %}<li><a id="labadmin-available-devices-toggle" href="" class="viewsitelink">{% trans "Available Devices" %}</a></li>
+	<div id="labadmin-available-devices" style="display: none">
+		<table>
+		<tr>
+		<th>IP</th>
+		<th>MAC</th>
+		</tr>
+		{% for ip, mac in labadmin_available_devices %}
+		<tr>
+		<td>{{ ip }}</td>
+		<td>{{ mac }}</td>
+		</tr>
+		{% endfor %}
+		</table>
+	</div>
+	{% endif %}
+    {% endblock %}
+  </ul>
+{% endif %}
+{% endblock %}
+
+{% block admin_change_form_document_ready %}
+<script type="text/javascript">
+django.jQuery('#labadmin-available-devices-toggle').click(function(event) {
+    event.preventDefault();
+    django.jQuery('#labadmin-available-devices').toggle();
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
When creating a new device in the admin show the list of devices
we have on our arp cache.
Visualization is a bit rough but works fine.

Fix #27